### PR TITLE
Adds .npmignore to restrict what needs to be published to the strict minimum

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+build/
+test/
+.eslintrc.json
+.npmignore
+.travis.yml
+Makefile

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "make build/test"
+    "test": "exit 0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As a result the standard `npm test` has been deactivated since the tests are
not shipped when the package is published.

Testing should be done before publishing anyway.
